### PR TITLE
Skip digest on map fragment cache so we can use fragment_exist? in …

### DIFF
--- a/app/views/catalog/_overview_map.html.erb
+++ b/app/views/catalog/_overview_map.html.erb
@@ -1,4 +1,4 @@
-<% cache(:action => "index", :action_suffix => "map")  do %>
+<% cache({controller: 'catalog', action: 'index', action_suffix: 'map'}, skip_digest: true)  do %>
   <script language="JavaScript">
     $(document).ready(function(){
       var options = {


### PR DESCRIPTION
…the controller to skip the API lookup.

(also including the controller explicitly in the cache key for good measure)